### PR TITLE
fix(episodes): add token argument in episodes.all() + create test

### DIFF
--- a/lib/betaseries/episodes.js
+++ b/lib/betaseries/episodes.js
@@ -17,13 +17,18 @@
     }, callbackError);
   }
 
-  Episodes.prototype.all = function(userId, showId, limit, subtitles, callbackSuccess, callbackError) {
-    _getList('list', 'shows', {
-      userId: userId || '',
+  Episodes.prototype.all = function(tokenId, userId, showId, limit, subtitles, callbackSuccess, callbackError) {
+    var params = {
+      token: tokenId,
       showId: showId || '',
       limit: limit || null,
       subtitles: subtitles || 'all',
-    }, callbackSuccess, callbackError);
+    }
+    if(userId){
+      params.userId = userId;
+    }
+
+    _getList('list', 'shows', params, callbackSuccess, callbackError);
   };
 
   Episodes.prototype.search = function(showId, episodeNumber, subtitles, callbackSuccess, callbackError) {

--- a/test/episodes.js
+++ b/test/episodes.js
@@ -1,9 +1,11 @@
 var assert = require('chai').assert,
+    user = require('./credentials'),
     BetaSeries = require('../index');
 
 describe('#valid', function() {
   var betaSeries = new BetaSeries(process.env.BETASERIES_API_KEY);
   var episodes = betaSeries.Episodes;
+  var auth = betaSeries.Auth;
 
   it('gets info about an episode', function(done) {
     var episodeId = 10;
@@ -24,6 +26,17 @@ describe('#valid', function() {
       assert(response.id == 164037, 'episode exists');
       assert(response.show.id == showId, 'show exists');
       done();
+    });
+  });
+
+  it('get episodes from connected user', function(done) {
+    var showId = 159;
+    auth.login(user.getUsername(), user.getPassword(), function(response){
+      assert(response.user.id == user.getId(), 'user connected');
+      episodes.all(response.token, null, showId, null, null, function(response) {
+        assert(response[0].id == showId, 'got episodes');
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Hello again,

as you asked, I created a new pull request to fix this issue.

When using `Episodes.prototype.all` : 

``` javascript
var BetaSerie = new (require('betaseries'))(API_KEY);
var episodes = BetaSerie.Episodes;
var userId = 27018;

episodes.all(userId, null, 4, null, function(shows){
   console.log(shows);
}, function(err, body){
   console.log(err, body);
});
```

An error is returned from the API 

``` json
// console.log(err, body);
{
    "errors": [
        {
            "code": 2001,
            "text": "Token invalide."
        }
    ]
}
```

We actually need a token, in the header or as a parameter. You can get it by using `Auth.prototype.login` from this [PR #1](https://github.com/mebibou/node-betaseries/pull/1)
When using a userId, the episodes fetched are those of this userId, even though the token is from an other user.

Thanks !

(The Travis CI build fails because there's currently no credentials.js)
